### PR TITLE
Fix: Change POST to PUT method in packages/<pk>/delivered end point

### DIFF
--- a/logistics/views.py
+++ b/logistics/views.py
@@ -129,7 +129,7 @@ def package_assign_courier(request, pk=None, courier_id=None):
     serializer = PackageSerializer(package)
     return Response(serializer.data)
     
-@api_view(['POST'])
+@api_view(['PUT'])
 def package_delivered(request, pk=None):
     try:
         package = Package.objects.get(pk=pk)


### PR DESCRIPTION
## Description

This pull request addresses a bug discovered in the `package_delivered` function within the Packages views in the Django Logistics app. The bug caused unexpected behavior when marking a package as delivered, and this fix aims to resolve the issue.

## Changes Made

- Identified and corrected the bug in the `package_delivered` function in `views.py`.
- Tested the updated functionality to ensure proper package delivery handling.

## Testing

- Conducted thorough testing to verify the bug fix.
- Confirmed that the corrected `package_delivered` function works as intended.

## Next Steps

- [x] Request code review to ensure the fix meets quality standards.
- [x] Confirm that the fix does not introduce any regressions in other areas.
- [x] Merge the changes into the main branch.
